### PR TITLE
Change gateway CID matcher to exclude URL fragments & queries

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(fetchStats())
   } else {
     // Gateway page
-    const match = path.match(/(\/ipfs\/.*?)(\#|\?|$)/)
+    const match = path.match(/(\/ipfs\/.*?)(#|\?|$)/)
     const ipfsPath = match[1]
 
     event.respondWith(fetchCID(ipfsPath))

--- a/src/index.js
+++ b/src/index.js
@@ -64,8 +64,7 @@ self.addEventListener('fetch', (event) => {
     event.respondWith(fetchStats())
   } else {
     // Gateway page
-    const regex = /^.+?(\/ipfs\/.+)$/g
-    const match = regex.exec(path)
+    const match = path.match(/(\/ipfs\/.*?)(\#|\?|$)/)
     const ipfsPath = match[1]
 
     event.respondWith(fetchCID(ipfsPath))

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,4 +1,4 @@
-/* global Request, self */
+/* global Request, self, Blob */
 /* eslint-env mocha */
 
 'use strict'
@@ -40,7 +40,42 @@ describe('Service worker', function () {
         expect(response).to.exist()
         expect(response.body).to.exist()
         expect(response.headers).to.exist()
+        expect(response.body).to.be.an.instanceof(Blob)
+        expect(response.body.parts[0].toString()).to.equal('hello world\n')
+        done()
+      })
+  })
 
+  it('should resolve query strings correctly', function (done) {
+    require('../src')
+    this.timeout(50 * 1000)
+
+    const multihash = 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
+
+    self.trigger('fetch', new Request(`/ipfs/${multihash}?everything=42`))
+      .then((response) => {
+        expect(response).to.exist()
+        expect(response.body).to.exist()
+        expect(response.headers).to.exist()
+        expect(response.body).to.be.an.instanceof(Blob)
+        expect(response.body.parts[0].toString()).to.equal('hello world\n')
+        done()
+      })
+  })
+
+  it('should resolve fragment identifiers correctly', function (done) {
+    require('../src')
+    this.timeout(50 * 1000)
+
+    const multihash = 'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o'
+
+    self.trigger('fetch', new Request(`/ipfs/${multihash}#/wumbo`))
+      .then((response) => {
+        expect(response).to.exist()
+        expect(response.body).to.exist()
+        expect(response.headers).to.exist()
+        expect(response.body).to.be.an.instanceof(Blob)
+        expect(response.body.parts[0].toString()).to.equal('hello world\n')
         done()
       })
   })


### PR DESCRIPTION
Currently js.ipfs.io breaks when one tries to reload Peerpad because it stores information in the URL fragment (for [example](https://js.ipfs.io/ipfs/QmfQiRPTxVTT31ecDMAcUgTSTDt2HdPHKTuDWnD7T689oi/index.html#)) (#blah) section of the URL, which this gateway tries to resolve as part of the IPFS path. 

This makes the behavior consistent with the other [gateways](https://gateway.ipfs.io/ipfs/QmfQiRPTxVTT31ecDMAcUgTSTDt2HdPHKTuDWnD7T689oi/index.html#) which ignore query strings and fragments. 