### PR TITLE
fix: shared data on different processes

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "debug": "^4.1.0",
     "file-type": "^10.5.0",
     "filesize": "^3.6.1",
+    "idb-keyval": "^3.0.5",
     "ipfs": "~0.33.1",
     "ipfs-http-response": "~0.2.1",
     "ipfs-postmsg-proxy": "^3.1.1",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "chai": "^4.2.0",
     "clear-module": "^3.0.0",
     "dirty-chai": "^2.0.1",
+    "fake-indexeddb": "^2.0.4",
     "ipfsd-ctl": "~0.40.0",
     "service-worker-mock": "^1.10.1"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -28,22 +28,10 @@ const fetchCID = (ipfsPath) => {
             date: getFormattedDate(d),
             time: getFormattedTime(d)
           })
-          return set('fetched-cids', fetchedCIDs).then((sth) => {
-            console.log('set')
 
-            return get('fetched-cids').then((v) => {
-              console.log('ipfsPath', ipfsPath)
-              console.log('fetched cids', fetchedCIDs)
-              console.log('v', ipfsPath, v)
-
-              return resp
-            })
-
-            // return resp
-          })
-
-          // return resp
+          return set('fetched-cids', fetchedCIDs).then(() => resp)
         })
+        .catch((err) => new Response(err.toString()))
     })
 }
 
@@ -52,11 +40,13 @@ const fetchStats = () => {
   return node.get()
     .then((ipfsNode) => {
       return Promise.all([ipfsNode.id(), ipfsNode.repo.stat(), get('fetched-cids'), get('start-date-time')])
-        .then(([id, stat, fetchedCIDs = [], startDateTime = {}]) => new Response(statsView.render(id, stat, fetchedCIDs, startDateTime), {
-          status: 200,
-          statusText: 'OK',
-          headers: { 'Content-Type': 'text/html' }
-        }))
+        .then(([id, stat, fetchedCIDs = [], startDateTime = {}]) => {
+          return new Response(statsView.render(id, stat, fetchedCIDs, startDateTime), {
+            status: 200,
+            statusText: 'OK',
+            headers: { 'Content-Type': 'text/html' }
+          })
+        })
         .catch((err) => new Response(err.toString()))
     })
 }

--- a/src/index.js
+++ b/src/index.js
@@ -3,8 +3,9 @@
 'use strict'
 
 const { createProxyServer } = require('ipfs-postmsg-proxy')
-
 const { getResponse } = require('ipfs-http-response')
+const { get, set } = require('idb-keyval')
+
 const node = require('./node')
 const statsView = require('./stats-view')
 
@@ -12,25 +13,37 @@ const getFormattedDate = (d) => `${d.getFullYear()}/${d.getMonth()}/${d.getDate(
 const getFormattedTime = (d) => `${d.getHours()}:${d.getMinutes()}:${d.getSeconds()}`
 
 let ipfsNode
-const fetchedCIDs = []
-let startDateTime = {
-  date: '',
-  time: ''
-}
 
 // Fetch CID
 const fetchCID = (ipfsPath) => {
   return node.get()
-    .then((ipfsNode) => getResponse(ipfsNode, ipfsPath))
-    .then((resp) => {
-      // Keep a record of the fetched CID (and fetch date)
-      const d = new Date()
-      fetchedCIDs.push({
-        cid: ipfsPath.split('/ipfs/')[1],
-        date: getFormattedDate(d),
-        time: getFormattedTime(d)
-      })
-      return resp
+    .then((ipfsNode) => {
+      return Promise.all([getResponse(ipfsNode, ipfsPath), get('fetched-cids')])
+        .then(([resp, fetchedCIDs = []]) => {
+          // Keep a record of the fetched CID (and fetch date)
+          const d = new Date()
+
+          fetchedCIDs.push({
+            cid: ipfsPath.split('/ipfs/')[1],
+            date: getFormattedDate(d),
+            time: getFormattedTime(d)
+          })
+          return set('fetched-cids', fetchedCIDs).then((sth) => {
+            console.log('set')
+
+            return get('fetched-cids').then((v) => {
+              console.log('ipfsPath', ipfsPath)
+              console.log('fetched cids', fetchedCIDs)
+              console.log('v', ipfsPath, v)
+
+              return resp
+            })
+
+            // return resp
+          })
+
+          // return resp
+        })
     })
 }
 
@@ -38,8 +51,8 @@ const fetchCID = (ipfsPath) => {
 const fetchStats = () => {
   return node.get()
     .then((ipfsNode) => {
-      return Promise.all([ipfsNode.id(), ipfsNode.repo.stat()])
-        .then(([id, stat]) => new Response(statsView.render(id, stat, fetchedCIDs, startDateTime), {
+      return Promise.all([ipfsNode.id(), ipfsNode.repo.stat(), get('fetched-cids'), get('start-date-time')])
+        .then(([id, stat, fetchedCIDs = [], startDateTime = {}]) => new Response(statsView.render(id, stat, fetchedCIDs, startDateTime), {
           status: 200,
           statusText: 'OK',
           headers: { 'Content-Type': 'text/html' }
@@ -84,10 +97,12 @@ self.addEventListener('activate', (event) => {
 
       // Keep a record of the start date and time of the IPFS Node
       const d = new Date()
-      startDateTime = {
+
+      set('fetched-cids', [])
+      set('start-date-time', {
         date: getFormattedDate(d),
         time: getFormattedTime(d)
-      }
+      })
     })
     .catch((err) => console.err(err))
   event.waitUntil(self.clients.claim())

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -10,7 +10,10 @@ chai.use(dirtyChai)
 
 const clearModule = require('clear-module')
 const makeServiceWorkerEnv = require('service-worker-mock')
+const indexedDB = require('fake-indexeddb')
+
 global.window = require('./helpers/mock-window')()
+global.indexedDB = indexedDB
 
 describe('Service worker', function () {
   beforeEach(() => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -45,6 +45,7 @@ describe('Service worker', function () {
         expect(response.headers).to.exist()
         expect(response.body).to.be.an.instanceof(Blob)
         expect(response.body.parts[0].toString()).to.equal('hello world\n')
+
         done()
       })
   })
@@ -62,6 +63,7 @@ describe('Service worker', function () {
         expect(response.headers).to.exist()
         expect(response.body).to.be.an.instanceof(Blob)
         expect(response.body.parts[0].toString()).to.equal('hello world\n')
+
         done()
       })
   })
@@ -79,6 +81,7 @@ describe('Service worker', function () {
         expect(response.headers).to.exist()
         expect(response.body).to.be.an.instanceof(Blob)
         expect(response.body.parts[0].toString()).to.equal('hello world\n')
+
         done()
       })
   })

--- a/test/node.spec.js
+++ b/test/node.spec.js
@@ -15,6 +15,7 @@ describe('Service worker running node', function () {
       .then((node) => {
         expect(node).to.exist()
         expect(node).to.have.property('repo')
+
         done()
       })
   })

--- a/test/stats-view.spec.js
+++ b/test/stats-view.spec.js
@@ -1,3 +1,4 @@
+/* eslint max-nested-callbacks: ["error", 6] */
 /* global Request, self */
 /* eslint-env mocha */
 
@@ -10,12 +11,15 @@ chai.use(dirtyChai)
 
 const clearModule = require('clear-module')
 const makeServiceWorkerEnv = require('service-worker-mock')
+const indexedDB = require('fake-indexeddb')
+
 global.window = require('./helpers/mock-window')()
+global.indexedDB = indexedDB
 
 const checkAll = (bits) => string => bits.every(bit => string.includes(bit))
 const checkAny = (bits) => string => bits.some(bit => string.includes(bit))
 
-describe('Stats view page', function () {
+describe.only('Stats view page', function () {
   beforeEach(() => {
     Object.assign(
       global,
@@ -24,17 +28,34 @@ describe('Stats view page', function () {
     clearModule('../src')
   })
 
-  it('should return the stats page with the fetched hashes correctly', function (done) {
+  it.only('should return the stats page with the fetched hashes correctly', function (done) {
     this.timeout(50 * 1000)
 
     require('../src')
 
-    Promise.all([self.trigger('fetch', new Request(`/ipfs/QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o`)),
+    Promise.all([
+      self.trigger('fetch', new Request(`/ipfs/QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o`)),
       self.trigger('fetch', new Request(`/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG`)),
       self.trigger('fetch', new Request(`/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about`))])
       .then((values) => {
         expect(values).to.exist()
 
+        setTimeout(() => {
+          self.trigger('fetch', new Request(`/stats`))
+            .then((response) => {
+              expect(response).to.exist()
+              expect(response.headers).to.exist()
+              expect(response.body).to.exist()
+              expect(response.body).to.satisfy(checkAll([
+                'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o',
+                'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
+                'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about'
+              ]))
+
+              done()
+            })
+        }, 2000)
+        /*
         self.trigger('fetch', new Request(`/stats`))
           .then((response) => {
             expect(response).to.exist()
@@ -47,10 +68,7 @@ describe('Stats view page', function () {
             ]))
 
             done()
-          })
-          .catch(() => {
-            expect(values).to.not.exist()
-          })
+          }) */
       })
   })
 

--- a/test/stats-view.spec.js
+++ b/test/stats-view.spec.js
@@ -19,7 +19,7 @@ global.indexedDB = indexedDB
 const checkAll = (bits) => string => bits.every(bit => string.includes(bit))
 const checkAny = (bits) => string => bits.some(bit => string.includes(bit))
 
-describe.only('Stats view page', function () {
+describe('Stats view page', function () {
   beforeEach(() => {
     Object.assign(
       global,
@@ -28,70 +28,69 @@ describe.only('Stats view page', function () {
     clearModule('../src')
   })
 
-  it.only('should return the stats page with the fetched hashes correctly', function (done) {
+  it('should return the stats page with empty fetched hashes correctly', function () {
     this.timeout(50 * 1000)
 
     require('../src')
 
-    Promise.all([
-      self.trigger('fetch', new Request(`/ipfs/QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o`)),
-      self.trigger('fetch', new Request(`/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG`)),
-      self.trigger('fetch', new Request(`/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about`))])
-      .then((values) => {
-        expect(values).to.exist()
-
-        setTimeout(() => {
-          self.trigger('fetch', new Request(`/stats`))
-            .then((response) => {
-              expect(response).to.exist()
-              expect(response.headers).to.exist()
-              expect(response.body).to.exist()
-              expect(response.body).to.satisfy(checkAll([
-                'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o',
-                'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
-                'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about'
-              ]))
-
-              done()
-            })
-        }, 2000)
-        /*
-        self.trigger('fetch', new Request(`/stats`))
-          .then((response) => {
-            expect(response).to.exist()
-            expect(response.headers).to.exist()
-            expect(response.body).to.exist()
-            expect(response.body).to.satisfy(checkAll([
-              'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o',
-              'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
-              'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about'
-            ]))
-
-            done()
-          }) */
-      })
-  })
-
-  it('should return the stats page with empty fetched hashes correctly', function (done) {
-    this.timeout(50 * 1000)
-
-    require('../src')
-
-    self.trigger('fetch', new Request(`/stats`))
+    return self.trigger('fetch', new Request(`/stats`))
       .then((response) => {
         expect(response).to.exist()
         expect(response.headers).to.exist()
         expect(response.body).to.exist()
         expect(response.body).to.not.satisfy(checkAny([
-          'QmT78zSuBmuS4z925WZfrqQ1qHaJ56DQaTfyMUF7F8ff5o',
+          'QmeYxwj4CwCeGVhwi3xLrmBZUUFQdftshSiGLrTdTnWEVV',
           'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
           'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about'
         ]))
+      })
+  })
+
+  it('should return the stats page with the fetched hashes correctly', function () {
+    this.timeout(50 * 1000)
+
+    require('../src')
+
+    return self.trigger('fetch', new Request(`/ipfs/QmeYxwj4CwCeGVhwi3xLrmBZUUFQdftshSiGLrTdTnWEVV`))
+      .then((response) => {
+        expect(response).to.exist()
+
+        return self.trigger('fetch', new Request(`/stats`))
+      })
+      .then((response) => {
+        expect(response).to.exist()
         expect(response.body).to.satisfy(checkAll([
-          'Any CID fetched so far'
+          'QmeYxwj4CwCeGVhwi3xLrmBZUUFQdftshSiGLrTdTnWEVV'
         ]))
 
-        done()
+        return self.trigger('fetch', new Request(`/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG`))
+      })
+      .then((response) => {
+        expect(response).to.exist()
+
+        return self.trigger('fetch', new Request(`/stats`))
+      })
+      .then((response) => {
+        expect(response).to.exist()
+        expect(response.body).to.satisfy(checkAll([
+          'QmeYxwj4CwCeGVhwi3xLrmBZUUFQdftshSiGLrTdTnWEVV',
+          'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG'
+        ]))
+
+        return self.trigger('fetch', new Request(`/ipfs/QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about`))
+      })
+      .then((response) => {
+        expect(response).to.exist()
+
+        return self.trigger('fetch', new Request(`/stats`))
+      })
+      .then((response) => {
+        expect(response).to.exist()
+        expect(response.body).to.satisfy(checkAll([
+          'QmeYxwj4CwCeGVhwi3xLrmBZUUFQdftshSiGLrTdTnWEVV',
+          'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG',
+          'QmYwAPJzv5CZsnA625s3Xf2nemtYgPpHdWEz79ojWnPbdG/about'
+        ]))
       })
   })
 })


### PR DESCRIPTION
Added indexeddb datastore for storing the stats page data. This aims to allow users in Firefox to use different tabs to check the stats page.

A refactor to the tests was also made.

In the context of [ipfs/js.ipfs.io#207](https://github.com/ipfs/js.ipfs.io/issues/207)

Closes #24 