### PR TITLE
preparations for js-ipfs 0.36

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "file-type": "^10.11.0",
     "filesize": "^4.1.2",
     "idb-keyval": "^3.2.0",
-    "ipfs": "~0.36.0-rc.0",
+    "ipfs": "~0.36.0",
     "ipfs-http-response": "~0.2.2",
     "ipfs-postmsg-proxy": "^3.1.1",
     "ipfs-unixfs": "~0.1.16",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "file-type": "^10.11.0",
     "filesize": "^4.1.2",
     "idb-keyval": "^3.2.0",
-    "ipfs": "0.35.0",
+    "ipfs": "~0.36.0-rc.0",
     "ipfs-http-response": "~0.2.2",
     "ipfs-postmsg-proxy": "^3.1.1",
     "ipfs-unixfs": "~0.1.16",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "filesize": "^4.1.2",
     "idb-keyval": "^3.2.0",
     "ipfs": "~0.36.0",
-    "ipfs-http-response": "~0.2.2",
+    "ipfs-http-response": "~0.3.0",
     "ipfs-postmsg-proxy": "^3.1.1",
     "ipfs-unixfs": "~0.1.16",
     "mime-types": "^2.1.22",


### PR DESCRIPTION
run the CI tests with ipfs@0.36.0-rc.0

of note, I'm seeing test failures locally on master as well as with
the latest ipfs 0.36 rc, so I'm sharing this PR to trigger CI to
see if it's just an issue on my machine.

see: https://github.com/ipfs/js-ipfs/issues/2024