### PR TITLE
docs: deprecation notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+# ⛔️ DEPRECATED
+
+_This example is out of date and will not be maintained._
+
+See the modern end-to-end example of using js-ipfs node in `SharedWorker` from `ServiceWorker` at [`ipfs/js-ipfs/examples/browser-service-worker`](https://github.com/ipfs/js-ipfs/tree/master/examples/browser-service-worker)
+
+
+---
+
+
 # service-worker-gateway
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)


### PR DESCRIPTION
> Part of ServiceWorker example cleanup: https://github.com/ipfs/in-web-browsers/issues/171

I suggest deprecate this repo (and NPM package),
but let me know if you still feel it is it worth allocating time and resource into updating and maintaining it in 2021.

I am leaning towards deprecation, as this lib is mostly superseded by lower-level libraries and example made by @gozala:
- https://www.npmjs.com/package/ipfs-message-port-client
- https://www.npmjs.com/package/ipfs-message-port-server
- [`ipfs/js-ipfs/examples/browser-service-worker`](https://github.com/ipfs/js-ipfs/tree/master/examples/browser-service-worker)

Those should be more useful to people, as they can integrate them into their own worker logic, while this library is mostly an opinionated PoC.

cc @vasco-santos @olizilla @alanshaw @achingbrain thoughts?